### PR TITLE
fix: only necessary to override the construction of the poetry instance.

### DIFF
--- a/poetry_multiproject_plugin/commands/project_build.py
+++ b/poetry_multiproject_plugin/commands/project_build.py
@@ -1,6 +1,5 @@
 from cleo.helpers import option
 from poetry.console.commands.build import BuildCommand
-from poetry.core.masonry.builder import Builder
 from poetry_multiproject_plugin.overrides import poetry_override
 from poetry_multiproject_plugin.repo import repo
 
@@ -16,16 +15,13 @@ class ProjectBuildCommand(BuildCommand):
 
     def handle(self) -> None:
         toml = self.option("toml") or repo.default_toml
-        fmt = self.option("format") or "all"
-
         modified = poetry_override.create_modified_poetry(self.poetry, toml)
 
+        self.set_poetry(modified)
+
         self.line(
-            f"Building <c1>{modified.package.pretty_name}</c1>"
-            f" (<c2>{modified.package.version}</c2>)."
-            f"\nUsing <c1>{modified.file.resolve()}.</c1>"
-            f"\nThe workspace folder is set to <c1>{modified.file.parent}</c1>."
+            f"Project file <c1>{modified.file.resolve()}</c1>"
+            f"\nWorkspace <c1>{modified.file.parent}</c1>"
         )
 
-        builder = Builder(modified)
-        builder.build(fmt, executable=self.env.python)
+        super(ProjectBuildCommand, self).handle()


### PR DESCRIPTION
Not necessary to override the rest of the build command actions in the Poetry builtin handle function.