### PR TITLE
fix: organize package includes in a root namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,40 +45,41 @@ Something like this will cause the build to fail:
 # this will fail using the default poetry build command
 
 packages = [
-    { include = "the_code_in_my_project"
-    { include = "../../../my-shared-package" }]
+    { include = "my_namespace/my_package" from = "../../my_shared_folder" }
+]
 ```
 
 By explicitly setting a workspace root, it is possible to reference outside components like this:
 
 ``` shell
-# this will work, when using the build-project command
-packages = [
-    { include = "the_code_in_my_project"
-    { include = "../../../my-shared-package" }]
+# this will work, when using the build-project command.
 
+# Note the structure of the shared folder: namespace/package/*.py
+
+packages = [
+    { include = "my_namespace/my_package" from = "../../my_shared_folder" }
+]
 ```
 
 Simplified example of a monorepo structure:
 
 ``` shell
 projects/
-  my-app/
+  my_app/
     pyproject.toml (including a shared package)
-    app.py
 
-  my-service/
+  my_service/
     pyproject.toml (including other shared packages)
-    app.py
 
 shared/
-  my-package/
-   __init__.py
-   code.py
+  my_namespace/
+    my_package/
+      __init__.py
+      code.py
 
-  my-other-package/
-   __init__.py
-   code.py
+    my_other_package/
+      __init__.py
+      code.py
 
 workspace.toml (a file that tells the plugin where to find the workspace root)
 ```

--- a/poetry_multiproject_plugin/__init__.py
+++ b/poetry_multiproject_plugin/__init__.py
@@ -1,5 +1,5 @@
 from poetry_multiproject_plugin.plugin import MultiProjectPlugin
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __all__ = ["MultiProjectPlugin"]

--- a/poetry_multiproject_plugin/overrides/builders.py
+++ b/poetry_multiproject_plugin/overrides/builders.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Optional
 
 from poetry.core.masonry.builders.builder import BuildIncludeFile
+from poetry_multiproject_plugin.workspace import namespacing
 
 
 def relative_to_workspace(target) -> Path:
@@ -20,7 +21,7 @@ def relative_to_project_root(self) -> Path:
 
 def relative_to_source_root(self) -> Path:
     if self.workspace:
-        return relative_to_workspace(self)
+        return namespacing.create_namespaced_path(self.path, self.workspace)
 
     if self.source_root is not None:
         return self.path.relative_to(self.source_root)

--- a/poetry_multiproject_plugin/workspace/namespacing.py
+++ b/poetry_multiproject_plugin/workspace/namespacing.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+
+def extract_namespace(path, workspace):
+    grandparent = path.parent.parent
+
+    return grandparent.name if len(grandparent.relative_to(workspace).name) else None
+
+
+def create_namespaced_path(path, workspace):
+    namespace = extract_namespace(path, workspace) or ""
+    package_name = path.parent.name
+    module_name = path.name
+
+    namespaced_path = "/".join([namespace, package_name, module_name])
+
+    return Path(namespaced_path)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "0.3.1"
+version = "0.3.2"
 description = "A Poetry plugin that aims to simplify package & dependency management for projects in Monorepos."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
… wheel and sdist are packaged into separate folders by default.