### PR TITLE
fix: check-project command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,23 @@ poetry self add poetry-multiproject-plugin
 
 ## What does it do?
 
-the `poetry build-command` will:
+the `poetry build-project` command will:
 
 1. copy the actual project into a temporary folder.
 2. collect relative includes - such as `include = "foo/bar", from = "../../shared"` -  and copy them into the temprary folder.
 3. generate a new pyproject.toml.
 4. run the `poetry build` command in the temporary folder.
 5. copy the built `dist` folder (containing the wheel and sdist) into the actual project folder.
+6. remove the temporary folder.
+
+
+the `poetry check-project` command will:
+
+1. copy the actual project into a temporary folder.
+2. collect relative includes - such as `include = "foo/bar", from = "../../shared"` -  and copy them into the temprary folder.
+3. generate a new pyproject.toml.
+4. run `poetry install` in the temporary folder.
+5. run `poetry run mypy` in the temporary folder.
 6. remove the temporary folder.
 
 

--- a/poetry_multiproject_plugin/components/check/mypy_checker.py
+++ b/poetry_multiproject_plugin/components/check/mypy_checker.py
@@ -11,18 +11,20 @@ default_args = [
 ]
 
 
-def run(dest: str, config_file: Union[str, None]) -> List[str]:
+def run(dest: str, top_ns: str, config_file: Union[str, None]) -> List[str]:
     os.environ["MYPYPATH"] = dest
 
     args = ["--config-file", config_file] if config_file else default_args
-    cmd = ["mypy"] + args + [f"{dest}/demo"]
+    cmd = ["poetry", "run", "mypy"] + args + [f"{dest}/{top_ns}"]
 
     res = subprocess.run(cmd, capture_output=True, text=True)
 
     return res.stdout.splitlines()
 
 
-def check_for_errors(destination: Path, config_file: Union[str, None]) -> List[str]:
-    lines = run(str(destination), config_file)
+def check_for_errors(
+    destination: Path, top_ns: str, config_file: Union[str, None]
+) -> List[str]:
+    lines = run(str(destination), top_ns, config_file)
 
     return [line for line in lines if "error:" in line]

--- a/poetry_multiproject_plugin/components/deps/__init__.py
+++ b/poetry_multiproject_plugin/components/deps/__init__.py
@@ -1,0 +1,3 @@
+from poetry_multiproject_plugin.components.deps.installer import install_deps
+
+__all__ = ["install_deps"]

--- a/poetry_multiproject_plugin/components/deps/installer.py
+++ b/poetry_multiproject_plugin/components/deps/installer.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+from pathlib import Path
+
+
+def run_install_command():
+    subprocess.run(["poetry", "install", "--only", "main", "--quiet"])
+
+
+def navigate_to(path: Path):
+    os.chdir(str(path))
+
+
+def install_deps(destination: Path):
+    current_dir = Path.cwd()
+
+    navigate_to(destination)
+    run_install_command()
+
+    navigate_to(current_dir)

--- a/poetry_multiproject_plugin/components/project/cleanup.py
+++ b/poetry_multiproject_plugin/components/project/cleanup.py
@@ -1,6 +1,11 @@
 import shutil
+import os
 from pathlib import Path
 
 
 def remove_project(project_path: Path):
     shutil.rmtree(project_path)
+
+
+def remove_file(project_path: Path, file_name: str):
+    os.remove(project_path / file_name)

--- a/poetry_multiproject_plugin/components/toml/read.py
+++ b/poetry_multiproject_plugin/components/toml/read.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+from typing import List
 
 from tomlkit.toml_document import TOMLDocument
 from tomlkit.toml_file import TOMLFile
+
+from poetry_multiproject_plugin.components.toml.packages import join_package_paths
 
 
 def toml(path: Path) -> TOMLDocument:
@@ -10,3 +13,10 @@ def toml(path: Path) -> TOMLDocument:
     toml_file = TOMLFile(p)
 
     return toml_file.read()
+
+
+def package_paths(path: Path) -> List[Path]:
+    data: dict = toml(path)
+    packages = data["tool"]["poetry"]["packages"]
+
+    return [join_package_paths(p) for p in packages]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.1.0"
+version = "1.1.1"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Fixes a non-functioning `check-project` command.

## Description
<!--- Describe your changes in detail -->
The command will install dependencies by using `poetry install` in a temp folder, then run `poetry run mypy` with a path to the project-specific top namespace.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
