### PR TITLE
fix: check-project command with reusable venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ the `poetry check-project` command will:
 6. remove the temporary folder.
 
 
+The default settings for the underlying `MyPy` configuration are:
+
+``` shell
+--explicit-package-bases --namespace-packages --no-error-summary --no-color-output
+```
+
+
 ## How is it different from the "poetry build" command?
 Poetry does not allow package includes outside of the __project__ root.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ the `poetry check-project` command will:
 6. remove the temporary folder.
 
 
-The default settings for the underlying `MyPy` configuration are:
+The default setting for the underlying `MyPy` configuration is:
 
 ``` shell
 --explicit-package-bases --namespace-packages --no-error-summary --no-color-output

--- a/poetry_multiproject_plugin/commands/checkproject/check.py
+++ b/poetry_multiproject_plugin/commands/checkproject/check.py
@@ -4,7 +4,7 @@ from typing import List
 
 from cleo.helpers import option
 from cleo.io.outputs.output import Verbosity
-from poetry.console.commands.build import BuildCommand
+from poetry.console.commands.command import Command
 from poetry.factory import Factory
 
 from poetry_multiproject_plugin.components.check import check_for_errors
@@ -31,7 +31,7 @@ def run_check(destination: Path, pyproj: str, config_file: str) -> List[str]:
     return [row.replace(dest, "") for row in flattened]
 
 
-class ProjectCheckCommand(BuildCommand):
+class ProjectCheckCommand(Command):
     name = command_name
 
     options = [
@@ -65,14 +65,13 @@ class ProjectCheckCommand(BuildCommand):
         self.prepare_for_build(project_path.absolute())
 
         self.io.set_verbosity(Verbosity.QUIET)
-        super(ProjectCheckCommand, self).handle()
-
-        mypy_config = self.option("config-file")
 
         cleanup.remove_file(project_path, "poetry.lock")
+        cleanup.remove_file(project_path, "poetry.toml")
 
         install_deps(project_path)
 
+        mypy_config = self.option("config-file")
         res = run_check(project_path, pyproj, mypy_config)
 
         self.io.set_verbosity(Verbosity.NORMAL)

--- a/poetry_multiproject_plugin/components/deps/installer.py
+++ b/poetry_multiproject_plugin/components/deps/installer.py
@@ -3,6 +3,11 @@ import subprocess
 from pathlib import Path
 
 
+def ensure_reusable_venv():
+    subprocess.run(["poetry", "config", "--local", "virtualenvs.in-project", "false"])
+    subprocess.run(["poetry", "config", "--local", "virtualenvs.path", "--unset"])
+
+
 def run_install_command():
     subprocess.run(["poetry", "install", "--only", "main", "--quiet"])
 
@@ -15,6 +20,7 @@ def install_deps(destination: Path):
     current_dir = Path.cwd()
 
     navigate_to(destination)
+    ensure_reusable_venv()
     run_install_command()
 
     navigate_to(current_dir)

--- a/poetry_multiproject_plugin/components/project/cleanup.py
+++ b/poetry_multiproject_plugin/components/project/cleanup.py
@@ -8,4 +8,7 @@ def remove_project(project_path: Path):
 
 
 def remove_file(project_path: Path, file_name: str):
-    os.remove(project_path / file_name)
+    try:
+        os.remove(project_path / file_name)
+    except FileNotFoundError:
+        pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.1.1"
+version = "1.1.2"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the Poetry global cache-dir for the temporary virtual environment that is created during `check-project`. This will speed up the process, and avoid unnecessary network calls.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Making the `check-project` command faster, because it can reuse a virtual environment already created.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CI ✅ 
Locally installed the plugin and tested in code repos.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
