### PR TITLE
fix: add support for global options

### DIFF
--- a/poetry_multiproject_plugin/commands/buildproject/project.py
+++ b/poetry_multiproject_plugin/commands/buildproject/project.py
@@ -37,7 +37,7 @@ class ProjectBuildCommand(BuildCommand):
         self.set_poetry(project_poetry)
 
     def handle(self):
-        path = Path("pyproject.toml").absolute()
+        path = self.poetry.file.path.absolute()
 
         self.line(f"Using <c1>{path}</c1>")
 

--- a/poetry_multiproject_plugin/commands/checkproject/check.py
+++ b/poetry_multiproject_plugin/commands/checkproject/check.py
@@ -58,23 +58,26 @@ class ProjectCheckCommand(Command):
         self.set_poetry(project_poetry)
 
     def handle(self):
-        pyproj = "pyproject.toml"
-        path = Path(pyproj).absolute()
+        is_verbose = self.option("verbose")
+        path = self.poetry.file.path.absolute()
 
         project_path = self.collect_project(path)
         self.prepare_for_build(project_path.absolute())
 
-        self.io.set_verbosity(Verbosity.QUIET)
+        if not is_verbose:
+            self.io.set_verbosity(Verbosity.QUIET)
 
         cleanup.remove_file(project_path, "poetry.lock")
         cleanup.remove_file(project_path, "poetry.toml")
 
-        install_deps(project_path)
+        install_deps(project_path, is_verbose)
 
         mypy_config = self.option("config-file")
-        res = run_check(project_path, pyproj, mypy_config)
+        res = run_check(project_path, "pyproject.toml", mypy_config)
 
-        self.io.set_verbosity(Verbosity.NORMAL)
+        if not is_verbose:
+            self.io.set_verbosity(Verbosity.NORMAL)
+
         for r in res:
             self.line(r)
 

--- a/poetry_multiproject_plugin/components/deps/installer.py
+++ b/poetry_multiproject_plugin/components/deps/installer.py
@@ -8,19 +8,20 @@ def ensure_reusable_venv():
     subprocess.run(["poetry", "config", "--local", "virtualenvs.path", "--unset"])
 
 
-def run_install_command():
-    subprocess.run(["poetry", "install", "--only", "main", "--quiet"])
+def run_install_command(is_verbose):
+    quiet = [] if is_verbose else ["--quiet"]
+    subprocess.run(["poetry", "install", "--only", "main"] + quiet)
 
 
 def navigate_to(path: Path):
     os.chdir(str(path))
 
 
-def install_deps(destination: Path):
+def install_deps(destination: Path, is_verbose: bool):
     current_dir = Path.cwd()
 
     navigate_to(destination)
     ensure_reusable_venv()
-    run_install_command()
+    run_install_command(is_verbose)
 
     navigate_to(current_dir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.1.2"
+version = "1.1.3"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding support for the `--directory` option in `build-project` and `check-project`

Adding support for the `--verbose` option in `check-project`, because this command mutes output by default

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #20 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CI ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
