### PR TITLE
fix(check-project): avoid unnecessary files

### DIFF
--- a/poetry_multiproject_plugin/components/deps/installer.py
+++ b/poetry_multiproject_plugin/components/deps/installer.py
@@ -10,7 +10,7 @@ def ensure_reusable_venv():
 
 def run_install_command(is_verbose):
     quiet = [] if is_verbose else ["--quiet"]
-    subprocess.run(["poetry", "install", "--only", "main"] + quiet)
+    subprocess.run(["poetry", "install", "--only", "main", "--no-root"] + quiet)
 
 
 def navigate_to(path: Path):

--- a/poetry_multiproject_plugin/components/project/prepare.py
+++ b/poetry_multiproject_plugin/components/project/prepare.py
@@ -29,7 +29,7 @@ def copy_project(project_file: Path, destination: Path) -> Path:
     res = shutil.copytree(
         source,
         destination,
-        ignore=shutil.ignore_patterns("*.pyc", "__pycache__", ".venv", ".mypy_cache"),
+        ignore=shutil.ignore_patterns("*.pyc", "__pycache__", ".venv", ".mypy_cache", "node_modules"),
         dirs_exist_ok=True,
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.1.5"
+version = "1.1.6"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
* There's no need to install the actual project in the temp virtual environment. Using the `--no-root` option of Poetry.
* Add the `node_modules` folder among common files and folders to avoid copying to the temp folder.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Making the `check-project` faster.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CI ✅ 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
