### PR TITLE
feat: rewrite top namespaces for relative includes when building packages

### DIFF
--- a/poetry_multiproject_plugin/components/parsing/__init__.py
+++ b/poetry_multiproject_plugin/components/parsing/__init__.py
@@ -1,0 +1,3 @@
+from poetry_multiproject_plugin.components.parsing.rewrite import rewrite_module
+
+__all__ = ["rewrite_module"]

--- a/poetry_multiproject_plugin/components/parsing/rewrite.py
+++ b/poetry_multiproject_plugin/components/parsing/rewrite.py
@@ -53,7 +53,7 @@ def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> No
     res = {mutate_imports(node, namespaces, top_ns) for node in ast.walk(tree)}
 
     if True in res:
-        rewritten_source_code = ast.unparse(tree)
+        rewritten_source_code = ast.unparse(tree)  # type: ignore[attr-defined]
 
         with open(file_path, "w") as f:
             f.write(rewritten_source_code)

--- a/poetry_multiproject_plugin/components/parsing/rewrite.py
+++ b/poetry_multiproject_plugin/components/parsing/rewrite.py
@@ -44,7 +44,7 @@ def mutate_imports(node: ast.AST, namespaces: List[str], top_ns: str) -> bool:
     return False
 
 
-def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> None:
+def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> bool:
     file_path = path.as_posix()
 
     with open(file_path, "r") as f:
@@ -57,3 +57,7 @@ def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> No
 
         with open(file_path, "w") as f:
             f.write(rewritten_source_code)
+
+        return True
+
+    return False

--- a/poetry_multiproject_plugin/components/parsing/rewrite.py
+++ b/poetry_multiproject_plugin/components/parsing/rewrite.py
@@ -1,6 +1,6 @@
 import ast
 import pathlib
-from typing import List, Set
+from typing import List
 
 
 def create_namespace_path(top_ns: str, current: str) -> str:

--- a/poetry_multiproject_plugin/components/parsing/rewrite.py
+++ b/poetry_multiproject_plugin/components/parsing/rewrite.py
@@ -1,0 +1,59 @@
+import ast
+import pathlib
+from typing import List, Set
+
+
+def create_namespace_path(top_ns: str, current: str) -> str:
+    return f"{top_ns}.{current}"
+
+
+def mutate_import(node: ast.Import, namespaces: List[str], top_ns: str) -> bool:
+    did_mutate = False
+
+    for alias in node.names:
+        if alias.name in namespaces:
+            alias.name = create_namespace_path(top_ns, alias.name)
+            did_mutate = True
+
+    return did_mutate
+
+
+def mutate_import_from(
+    node: ast.ImportFrom, namespaces: List[str], top_ns: str
+) -> bool:
+    did_mutate = False
+
+    if not node.module or node.level != 0:
+        return did_mutate
+
+    for namespace in namespaces:
+        if node.module == namespace or node.module.startswith(f"{namespace}."):
+            node.module = create_namespace_path(top_ns, node.module)
+            did_mutate = True
+
+    return did_mutate
+
+
+def mutate_imports(node: ast.AST, namespaces: List[str], top_ns: str) -> bool:
+    if isinstance(node, ast.Import):
+        return mutate_import(node, namespaces, top_ns)
+
+    if isinstance(node, ast.ImportFrom):
+        return mutate_import_from(node, namespaces, top_ns)
+
+    return False
+
+
+def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> None:
+    file_path = path.as_posix()
+
+    with open(file_path, "r") as f:
+        tree = ast.parse(f.read(), path.name)
+
+    res = {mutate_imports(node, namespaces, top_ns) for node in ast.walk(tree)}
+
+    if True in res:
+        rewritten_source_code = ast.unparse(tree)
+
+        with open(file_path, "w") as f:
+            f.write(rewritten_source_code)

--- a/poetry_multiproject_plugin/components/project/create.py
+++ b/poetry_multiproject_plugin/components/project/create.py
@@ -1,11 +1,14 @@
 from pathlib import Path
+from typing import Union
 
 from poetry_multiproject_plugin.components.toml import generate, read
 
 
-def create_new_project_file(project_file: Path, destination: Path) -> Path:
+def create_new_project_file(
+    project_file: Path, destination: Path, top_ns: Union[str, None] = None
+) -> Path:
     original = read.toml(project_file)
-    generated = generate.generate_valid_dist_project_file(original)
+    generated = generate.generate_valid_dist_project_file(original, top_ns)
 
     destination = Path(destination / project_file.name)
 

--- a/poetry_multiproject_plugin/components/project/packages.py
+++ b/poetry_multiproject_plugin/components/project/packages.py
@@ -14,7 +14,7 @@ def copy_packages(project_file: Path, destination: Path, top_ns: Union[str, None
         source = Path(project_file.parent / p["from"])
 
         top_ns_path = f"{top_ns}/" if top_ns else ""
-        to = Path(destination / top_ns_path + p["to"])
+        to = Path(destination / top_ns_path / p["to"])
 
         shutil.copytree(
             source,

--- a/poetry_multiproject_plugin/components/project/packages.py
+++ b/poetry_multiproject_plugin/components/project/packages.py
@@ -6,15 +6,22 @@ from poetry_multiproject_plugin.components.toml import read
 from poetry_multiproject_plugin.components.toml.packages import packages_to_paths
 
 
-def copy_packages(project_file: Path, destination: Path, top_ns: Union[str, None] = None):
+def copy_packages(
+    project_file: Path, destination: Path, top_ns: Union[str, None] = None
+) -> None:
     content = read.toml(project_file)
     package_paths = packages_to_paths(content)
 
     for p in package_paths:
-        source = Path(project_file.parent / p["from"])
+        p_from = p["from"]
+        p_to = p["to"]
+        source = Path(project_file.parent / p_from)
 
-        top_ns_path = f"{top_ns}/" if top_ns else ""
-        to = Path(destination / top_ns_path / p["to"])
+        is_relative_path = str(p_from).startswith("..")
+
+        to = f"{top_ns}/{p_to}" if top_ns and is_relative_path else p_to
+
+        to = Path(destination / to)
 
         shutil.copytree(
             source,

--- a/poetry_multiproject_plugin/components/project/packages.py
+++ b/poetry_multiproject_plugin/components/project/packages.py
@@ -1,17 +1,20 @@
 import shutil
 from pathlib import Path
+from typing import Union
 
 from poetry_multiproject_plugin.components.toml import read
 from poetry_multiproject_plugin.components.toml.packages import packages_to_paths
 
 
-def copy_packages(project_file: Path, destination: Path):
+def copy_packages(project_file: Path, destination: Path, top_ns: Union[str, None] = None):
     content = read.toml(project_file)
     package_paths = packages_to_paths(content)
 
     for p in package_paths:
         source = Path(project_file.parent / p["from"])
-        to = Path(destination / p["to"])
+
+        top_ns_path = f"{top_ns}/" if top_ns else ""
+        to = Path(destination / top_ns_path + p["to"])
 
         shutil.copytree(
             source,

--- a/poetry_multiproject_plugin/components/project/prepare.py
+++ b/poetry_multiproject_plugin/components/project/prepare.py
@@ -1,5 +1,7 @@
+import re
 import shutil
 from pathlib import Path
+from typing import Union
 
 from poetry_multiproject_plugin.components.toml import read
 
@@ -29,3 +31,7 @@ def copy_project(project_file: Path, destination: Path) -> Path:
     )
 
     return Path(res)
+
+
+def normalize_top_namespace(namespace: Union[str, None]) -> Union[str, None]:
+    return re.sub("[^a-zA-Z_]", "", namespace) if namespace else None

--- a/poetry_multiproject_plugin/components/project/prepare.py
+++ b/poetry_multiproject_plugin/components/project/prepare.py
@@ -1,14 +1,7 @@
 import shutil
 from pathlib import Path
-from typing import cast
 
 from poetry_multiproject_plugin.components.toml import read
-
-
-def get_project_name(project_file: Path) -> str:
-    content = cast(dict, read.toml(project_file))
-
-    return content["tool"]["poetry"]["name"]
 
 
 def get_destination(project_file: Path, prefix: str) -> Path:
@@ -17,7 +10,7 @@ def get_destination(project_file: Path, prefix: str) -> Path:
     if project_file.parent == grandparent:
         raise ValueError(f"Failed to navigate to the parent of {project_file.parent}")
 
-    project_name = get_project_name(project_file)
+    project_name = read.project_name(project_file)
     sibling = f".{prefix}_{project_name}"
 
     return Path(grandparent / sibling)
@@ -29,7 +22,9 @@ def copy_project(project_file: Path, destination: Path) -> Path:
     res = shutil.copytree(
         source,
         destination,
-        ignore=shutil.ignore_patterns("*.pyc", "__pycache__", ".venv", ".mypy_cache", "node_modules"),
+        ignore=shutil.ignore_patterns(
+            "*.pyc", "__pycache__", ".venv", ".mypy_cache", "node_modules"
+        ),
         dirs_exist_ok=True,
     )
 

--- a/poetry_multiproject_plugin/components/toml/generate.py
+++ b/poetry_multiproject_plugin/components/toml/generate.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, cast
+from typing import Dict, List, Union, cast
 
 import tomlkit
 from tomlkit.toml_document import TOMLDocument
@@ -14,29 +14,37 @@ def is_relative(package: Dict[str, str]) -> bool:
     return "from" in package and ".." in package.get("from", "")
 
 
+def to_include(include: str) -> dict:
+    return {"include": include}
+
+
 def relative_to_local(packages) -> List[Dict[str, str]]:
     relative = [p for p in packages if is_relative(p)]
     includes = {extract_top_namespace(p["include"]) for p in relative}
 
-    return [{"include": i} for i in includes]
+    return [to_include(i) for i in includes]
 
 
-def to_valid_dist_packages(data: dict) -> List[Dict[str, str]]:
+def to_valid_dist_packages(
+    data: dict, top_ns: Union[str, None]
+) -> List[Dict[str, str]]:
     packages = data["tool"]["poetry"]["packages"]
 
     local = [p for p in packages if not is_relative(p)]
-    modified = relative_to_local(packages)
+    modified = [to_include(top_ns)] if top_ns else relative_to_local(packages)
 
     return local + modified
 
 
-def generate_valid_dist_project_file(data: TOMLDocument) -> str:
+def generate_valid_dist_project_file(
+    data: TOMLDocument, top_ns: Union[str, None]
+) -> str:
     """Returns a project file with any relative package includes rearranged,
     according to what is expected by the Poetry tool
     """
     original = tomlkit.dumps(data)
     copy = cast(dict, tomlkit.parse(original))
-    dist_packages = to_valid_dist_packages(copy)
+    dist_packages = to_valid_dist_packages(copy, top_ns)
 
     copy["tool"]["poetry"]["packages"].clear()
 

--- a/poetry_multiproject_plugin/components/toml/generate.py
+++ b/poetry_multiproject_plugin/components/toml/generate.py
@@ -31,9 +31,13 @@ def to_valid_dist_packages(
     packages = data["tool"]["poetry"]["packages"]
 
     local = [p for p in packages if not is_relative(p)]
-    modified = [to_include(top_ns)] if top_ns else relative_to_local(packages)
 
-    return local + modified
+    relative_packages = relative_to_local(packages)
+
+    if top_ns and relative_packages:
+        return local + [to_include(top_ns)]
+
+    return local + relative_packages
 
 
 def generate_valid_dist_project_file(

--- a/poetry_multiproject_plugin/components/toml/read.py
+++ b/poetry_multiproject_plugin/components/toml/read.py
@@ -32,4 +32,4 @@ def project_name(path: Path) -> str:
 def normalized_project_name(path: Path) -> str:
     name = project_name(path)
 
-    return re.sub("[^a-zA-Z]", "", name)
+    return re.sub("[^a-zA-Z_]", "", name)

--- a/poetry_multiproject_plugin/components/toml/read.py
+++ b/poetry_multiproject_plugin/components/toml/read.py
@@ -1,4 +1,3 @@
-import re
 from pathlib import Path
 from typing import List
 
@@ -27,9 +26,3 @@ def project_name(path: Path) -> str:
     data: dict = toml(path)
 
     return data["tool"]["poetry"]["name"]
-
-
-def normalized_project_name(path: Path) -> str:
-    name = project_name(path)
-
-    return re.sub("[^a-zA-Z_]", "", name)

--- a/poetry_multiproject_plugin/components/toml/read.py
+++ b/poetry_multiproject_plugin/components/toml/read.py
@@ -20,3 +20,15 @@ def package_paths(path: Path) -> List[Path]:
     packages = data["tool"]["poetry"]["packages"]
 
     return [join_package_paths(p) for p in packages]
+
+
+def project_name(path: Path) -> str:
+    data: dict = toml(path)
+
+    return data["tool"]["poetry"]["name"]
+
+
+def normalized_project_name(path: Path) -> str:
+    name = project_name(path)
+
+    return name.replace("-", "_")

--- a/poetry_multiproject_plugin/components/toml/read.py
+++ b/poetry_multiproject_plugin/components/toml/read.py
@@ -1,3 +1,4 @@
+import re
 from pathlib import Path
 from typing import List
 
@@ -31,4 +32,4 @@ def project_name(path: Path) -> str:
 def normalized_project_name(path: Path) -> str:
     name = project_name(path)
 
-    return name.replace("-", "_")
+    return re.sub("[^a-zA-Z]", "", name)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This PR will make it possible to support the use case for publishing  PyPI package(s) from a Python Monorepo.

When projects includes shared packages, they will have the same top namespace. This can be a problem when libraries, that originates from projects built from the same monorepo, will be installed into the same virtual environment.

Since Python libraries are installed in a "flat" folder structure, two libraries with the same top namespace will collide.

This Pull Request will offer a solution to this, by choosing a custom namespace to be used in the build process. Then organize the namespaced packages, and more importantly, re-write the imports made in the source code.

The re-organizing and re-writing is performed on the relative includes.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local testing with example repositories, CI linting.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
