### PR TITLE
fix(build-project): accidentally overwriting options

### DIFF
--- a/poetry_multiproject_plugin/commands/buildproject/project.py
+++ b/poetry_multiproject_plugin/commands/buildproject/project.py
@@ -1,7 +1,8 @@
 from pathlib import Path
-from typing import Union
+from typing import List, Union
 
 from cleo.helpers import option
+from cleo.io.inputs.option import Option
 from poetry.console.commands.build import BuildCommand
 from poetry.factory import Factory
 
@@ -17,7 +18,7 @@ from poetry_multiproject_plugin.components.project import (
 command_name = "build-project"
 
 
-def create_command_options():
+def create_command_options() -> List[Option]:
     parent = BuildCommand.options or []
 
     current = [

--- a/poetry_multiproject_plugin/commands/buildproject/project.py
+++ b/poetry_multiproject_plugin/commands/buildproject/project.py
@@ -17,16 +17,24 @@ from poetry_multiproject_plugin.components.project import (
 command_name = "build-project"
 
 
-class ProjectBuildCommand(BuildCommand):
-    name = command_name
+def create_command_options():
+    parent = BuildCommand.options or []
 
-    options = [
+    current = [
         option(
             long_name="with-top-namespace",
             description="To arrange relative includes, and to modify import statements.",
             flag=False,
         )
     ]
+
+    return parent + current
+
+
+class ProjectBuildCommand(BuildCommand):
+    name = command_name
+
+    options = create_command_options()
 
     def collect_project(self, path: Path, top_ns: Union[str, None]) -> Path:
         destination = prepare.get_destination(path, "prepare")
@@ -70,7 +78,7 @@ class ProjectBuildCommand(BuildCommand):
 
         self.line(f"Using <c1>{path}</c1>")
 
-        top_ns = prepare.normalize_top_namespace(self.option("with-top-ns"))
+        top_ns = prepare.normalize_top_namespace(self.option("with-top-namespace"))
         project_path = self.collect_project(path, top_ns)
 
         if top_ns:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `build-project` command unintentionally had overwritten the poetry `build` command options.

Also, a typo in how the new `with-top-namespace` option was picked up.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #28 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Installed a new version with the code in this Pull Request.

Ran `build-project` with, and without, the `-f` flag, in combination with the `with-top-namespace` flag.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
