### PR TITLE
fix: Poetry 1.5 TOML parsing issues in windows

### DIFF
--- a/poetry_multiproject_plugin/components/parsing/rewrite.py
+++ b/poetry_multiproject_plugin/components/parsing/rewrite.py
@@ -47,7 +47,7 @@ def mutate_imports(node: ast.AST, namespaces: List[str], top_ns: str) -> bool:
 def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> bool:
     file_path = path.as_posix()
 
-    with open(file_path, "r") as f:
+    with open(file_path, "r", encoding="utf-8") as f:
         tree = ast.parse(f.read(), path.name)
 
     res = {mutate_imports(node, namespaces, top_ns) for node in ast.walk(tree)}
@@ -55,7 +55,7 @@ def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> bo
     if True in res:
         rewritten_source_code = ast.unparse(tree)  # type: ignore[attr-defined]
 
-        with open(file_path, "w") as f:
+        with open(file_path, "w", encoding="utf-8") as f:
             f.write(rewritten_source_code)
 
         return True

--- a/poetry_multiproject_plugin/components/parsing/rewrite.py
+++ b/poetry_multiproject_plugin/components/parsing/rewrite.py
@@ -55,7 +55,7 @@ def rewrite_module(path: pathlib.Path, namespaces: List[str], top_ns: str) -> bo
     if True in res:
         rewritten_source_code = ast.unparse(tree)  # type: ignore[attr-defined]
 
-        with open(file_path, "w", encoding="utf-8") as f:
+        with open(file_path, "w", encoding="utf-8", newline="") as f:
             f.write(rewritten_source_code)
 
         return True

--- a/poetry_multiproject_plugin/components/project/create.py
+++ b/poetry_multiproject_plugin/components/project/create.py
@@ -12,7 +12,7 @@ def create_new_project_file(
 
     destination = Path(destination / project_file.name)
 
-    with open(destination.as_posix(), "w") as f:
+    with open(destination.as_posix(), "w", encoding="utf-8") as f:
         f.write(generated)
 
     return destination

--- a/poetry_multiproject_plugin/components/project/create.py
+++ b/poetry_multiproject_plugin/components/project/create.py
@@ -12,7 +12,7 @@ def create_new_project_file(
 
     destination = Path(destination / project_file.name)
 
-    with open(destination.as_posix(), "w", encoding="utf-8") as f:
+    with open(destination.as_posix(), "w", encoding="utf-8", newline="") as f:
         f.write(generated)
 
     return destination

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.2.1"
+version = "1.2.2"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
A problem occurs when writing TOML files with Windows newlines (CRLF) and later opening the file in Poetry 1.5 (using a different TOML parser).

This PR solves this, by leaving carriage reruns unchanged. Also adding explicit "utf-8" encoding when opening files.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #30 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Local install on Mac OS X.
Local install on Windows 10 (reproducing the error, and verifying the solution works).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
