### PR TITLE
add / to the allowlist filter when normalizing the top-namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ The `build-project` command, with a custom top namespace:
 poetry build-project --with-top-namespace my_namespace
 ```
 
+#### Namespace with slashes
+The `--with-top-namespace` argument can also be used with a forward slash `/` and this will create a path with the slash
+as well as the module/import will the accessible with the new slash.
+
+Example with `--with-top-namespace foo/bar`:
+```python
+from foo.bar import baz
+```
+
 #### The build output
 
 Default behaviour of `build-project` (i.e. without any custom top namespace flag):

--- a/README.md
+++ b/README.md
@@ -57,25 +57,16 @@ The `build-project` command, with a custom top namespace:
 poetry build-project --with-top-namespace my_namespace
 ```
 
-#### Namespace with slashes
-The `--with-top-namespace` argument can also be used with a forward slash `/` and this will create a path with the slash
-as well as the module/import will the accessible with the new slash.
-
-Example with `--with-top-namespace foo/bar`:
-```python
-from foo.bar import baz
-```
-
 #### The build output
 
-Default behaviour of `build-project` (i.e. without any custom top namespace flag):
+###### Default(no flag)
 ```shell
 /my_package
    __init__.py
    my_module.py
 ```
 
-By using the `--with-top-namespace` flag, the built artifact will look something like this:
+###### Namespace(`--with-top-namespace=my_namespace`)
 ```shell
 my_namespace/
     /my_package
@@ -83,16 +74,29 @@ my_namespace/
        my_module.py
 ```
 
+###### Namespace with path(`--with-top-namespace=my_namespace/subdir`)
+```shell
+my_namespace/
+    /my_package
+        /subdir
+           __init__.py
+           my_module.py
+```
 And will re-write the relevant module(s):
 
-(before)
+###### Default(no flag)
 ```python
 from my_package import my_function
 ```
 
-(after)
+###### Namespace(`--with-top-namespace=my_namespace`)
 ```python
 from my_namespace.my_package import my_function
+```
+
+###### Namespace with path(`--with-top-namespace=my_namespace/subdir`)
+```python
+from my_namespace.subdir.my_package import my_function
 ```
 
 ##### How is this done?

--- a/poetry_multiproject_plugin/components/project/prepare.py
+++ b/poetry_multiproject_plugin/components/project/prepare.py
@@ -34,4 +34,4 @@ def copy_project(project_file: Path, destination: Path) -> Path:
 
 
 def normalize_top_namespace(namespace: Union[str, None]) -> Union[str, None]:
-    return re.sub("[^a-zA-Z_]", "", namespace) if namespace else None
+    return re.sub("[^a-zA-Z_/]", "", namespace) if namespace else None


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Adding the forward slash `/` to the filter for top-namespace when normalizing
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We would like to create a top level with something like `foo/bar` so that the module can be imported as `import foo.bar.stuff`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Tested this locally on my mac. Should work on most *nix systems, but I'm not certain how it will impact Windows.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [X] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [X] I have updated the documentation accordingly (if applicable).
