### PR TITLE
fix: extend ignore patterns for build and check project commands

### DIFF
--- a/poetry_multiproject_plugin/components/project/packages.py
+++ b/poetry_multiproject_plugin/components/project/packages.py
@@ -26,6 +26,8 @@ def copy_packages(
         shutil.copytree(
             source,
             to,
-            ignore=shutil.ignore_patterns("__pycache__", ".mypy_cache"),
+            ignore=shutil.ignore_patterns(
+                "__pycache__", ".venv", ".mypy_cache", ".git"
+            ),
             dirs_exist_ok=True,
         )

--- a/poetry_multiproject_plugin/components/project/prepare.py
+++ b/poetry_multiproject_plugin/components/project/prepare.py
@@ -25,7 +25,12 @@ def copy_project(project_file: Path, destination: Path) -> Path:
         source,
         destination,
         ignore=shutil.ignore_patterns(
-            "*.pyc", "__pycache__", ".venv", ".mypy_cache", "node_modules"
+            "*.pyc",
+            "__pycache__",
+            ".venv",
+            ".mypy_cache",
+            "node_modules",
+            ".git",
         ),
         dirs_exist_ok=True,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.3.0"
+version = "1.3.1"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 homepage = "https://github.com/davidvujic/poetry-multiproject-plugin"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Extend the ignore copy pattern for the `build-project` and `check-project` commands.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes #38 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
CircleCI passed
Local install and test the commands on the python-polylith-example repo.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [ ] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
