### PR TITLE
fix(build-project): rewrite the CLI endpoint when there is relative includes matching the namespace

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.4.0"
+version = "1.4.1"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 license = "MIT"

--- a/test/components/toml/generate_test.py
+++ b/test/components/toml/generate_test.py
@@ -18,7 +18,17 @@ packages = [
 ]
 
 [tool.poetry.scripts]
-my_cli = "my.console.app:run"
+my_cli = "hello.console.app:run"
+"""
+
+pyproject_cli_with_local_modules = """\
+[tool.poetry]
+packages = [
+    {include = "hello", from = "../world"},
+]
+
+[tool.poetry.scripts]
+my_cli = "my_local_module.console.app:run"
 """
 
 
@@ -45,16 +55,22 @@ def test_generate_project_file_with_custom_namespace_for_packages():
 def test_generate_project_file_with_custom_namespace_in_script_entry_point():
     data = generate_toml(pyproject_cli, "xyz")
 
-    assert data["tool"]["poetry"]["scripts"] == {"my_cli": "xyz.my.console.app:run"}
+    assert data["tool"]["poetry"]["scripts"] == {"my_cli": "xyz.hello.console.app:run"}
 
 
 def test_generate_project_file_with_unchanged_script_entry_point():
-    data = generate_toml(pyproject_cli, "my")
+    data = generate_toml(pyproject_cli, "hello")
 
-    assert data["tool"]["poetry"]["scripts"] == {"my_cli": "my.console.app:run"}
+    assert data["tool"]["poetry"]["scripts"] == {"my_cli": "hello.console.app:run"}
 
 
 def test_generate_project_file_with_unchanged_script_entry_point_when_ns_is_in_path():
     data = generate_toml(pyproject_cli, "console")
 
-    assert data["tool"]["poetry"]["scripts"] == {"my_cli": "my.console.app:run"}
+    assert data["tool"]["poetry"]["scripts"] == {"my_cli": "hello.console.app:run"}
+
+
+def test_generate_project_file_with_unchanged_script_entry_point_using_local_module():
+    data = generate_toml(pyproject_cli_with_local_modules, "xyz")
+
+    assert data["tool"]["poetry"]["scripts"] == {"my_cli": "my_local_module.console.app:run"}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing an issue introduced in v1.4.0, where it is assumed that script entrypoints are located in relative includes and then rewrite the path to an entry point. This is when using the `--with-top-namespace` flag.

This PR will check if the entry point is located in the relative includes, and if so rewrite the path.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
More info in issue #51 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Unit tests
✅ Local install and run build-project

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
