### PR TITLE
feat(build-project): adding an option to set a custom temp path to use during project-build

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,20 @@ Check the code, with a custom `MyPy` configuration to override the defaults:
 poetry check-project --config-file <PATH-TO-MYPY.INI-CONFIG-FILE>
 ```
 
+### Available command options
+
+#### Custom temp path
+A custom temporary path to use for reading, writing and deleting project content during the project build.
+This option is useful for environments with restrictions on where scripts are allowed to store content.
+
+The default temp path will be created as a sibling to the project to build, and is the recommended way in most cases.
+
+``` shell
+poetry build-project --custom-temp-path /tmp
+poetry check-project --custom-temp-path /tmp
+```
+
+
 ### Usage for libraries
 The `build-project` has a solution to the problem with top namespaces in libraries for __Python 3.9__ and more.
 You can choose a custom namespace to be used in the build process, by using the `--with-top-namespace` flag. 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ poetry check-project --config-file <PATH-TO-MYPY.INI-CONFIG-FILE>
 A custom temporary path to use for reading, writing and deleting project content during the project build.
 This option is useful for environments with restrictions on where scripts are allowed to store content.
 
-The default temp path will be created as a sibling to the project to build, and is the recommended way in most cases.
+NOTE: The default temp path will be created as a sibling to the project to build, and is the recommended way in most cases.
 
 ``` shell
 poetry build-project --custom-temp-path /tmp

--- a/poetry_multiproject_plugin/commands/buildproject/project.py
+++ b/poetry_multiproject_plugin/commands/buildproject/project.py
@@ -26,7 +26,12 @@ def create_command_options() -> List[Option]:
             long_name="with-top-namespace",
             description="To arrange relative includes, and to modify import statements.",
             flag=False,
-        )
+        ),
+        option(
+            long_name="custom-temp-path",
+            description="Temporary path to use for reading, writing and deleting content during the project build.",
+            flag=False,
+        ),
     ]
 
     return parent + current
@@ -37,8 +42,10 @@ class ProjectBuildCommand(BuildCommand):
 
     options = create_command_options()
 
-    def collect_project(self, path: Path, top_ns: Union[str, None]) -> Path:
-        destination = prepare.get_destination(path, "prepare")
+    def collect_project(
+        self, path: Path, top_ns: Union[str, None], temp_path: Union[str, None]
+    ) -> Path:
+        destination = prepare.get_destination(path, "prepare", temp_path)
 
         prepare.copy_project(path, destination)
         packages.copy_packages(path, destination, top_ns)
@@ -80,7 +87,9 @@ class ProjectBuildCommand(BuildCommand):
         self.line(f"Using <c1>{path}</c1>")
 
         top_ns = prepare.normalize_top_namespace(self.option("with-top-namespace"))
-        project_path = self.collect_project(path, top_ns)
+        temp_path = self.option("custom-temp-path")
+
+        project_path = self.collect_project(path, top_ns, temp_path)
 
         if top_ns:
             self.rewrite_modules(project_path, top_ns)

--- a/poetry_multiproject_plugin/commands/checkproject/check.py
+++ b/poetry_multiproject_plugin/commands/checkproject/check.py
@@ -1,6 +1,6 @@
 import itertools
 from pathlib import Path
-from typing import List
+from typing import List, Union
 
 from cleo.helpers import option
 from cleo.io.outputs.output import Verbosity
@@ -44,11 +44,16 @@ class ProjectCheckCommand(Command):
             long_name="config-file",
             description="Path to mypy config file. Use it to override the defaults.",
             flag=False,
-        )
+        ),
+        option(
+            long_name="custom-temp-path",
+            description="Temporary path to use for reading, writing and deleting content during the project check.",
+            flag=False,
+        ),
     ]
 
-    def collect_project(self, path: Path) -> Path:
-        destination = prepare.get_destination(path, "check")
+    def collect_project(self, path: Path, temp_path: Union[str, None]) -> Path:
+        destination = prepare.get_destination(path, "check", temp_path)
 
         prepare.copy_project(path, destination)
         packages.copy_packages(path, destination)
@@ -64,9 +69,11 @@ class ProjectCheckCommand(Command):
 
     def handle(self):
         is_verbose = self.option("verbose")
+        temp_path = self.option("custom-temp-path")
+
         path = self.poetry.file.path.absolute()
 
-        project_path = self.collect_project(path)
+        project_path = self.collect_project(path, temp_path)
         self.prepare_for_build(project_path.absolute())
 
         if not is_verbose:

--- a/poetry_multiproject_plugin/components/project/prepare.py
+++ b/poetry_multiproject_plugin/components/project/prepare.py
@@ -6,16 +6,27 @@ from poetry_multiproject_plugin.components.project import copying
 from poetry_multiproject_plugin.components.toml import read
 
 
-def get_destination(project_file: Path, prefix: str) -> Path:
+def get_destination_folder(project_file: Path, temp_path: Union[str, None]) -> Path:
+    if temp_path:
+        return Path(temp_path)
+
     grandparent = project_file.parent.parent
 
     if project_file.parent == grandparent:
         raise ValueError(f"Failed to navigate to the parent of {project_file.parent}")
 
+    return grandparent
+
+
+def get_destination(
+    project_file: Path, prefix: str, temp_path: Union[str, None]
+) -> Path:
+    folder = get_destination_folder(project_file, temp_path)
+
     project_name = read.project_name(project_file)
     sibling = f".{prefix}_{project_name}"
 
-    return Path(grandparent / sibling)
+    return Path(folder / sibling)
 
 
 def copy_project(project_file: Path, destination: Path) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.6.0"
+version = "1.7.0"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 license = "MIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adding an option `--custom-temp-path` to be able to set the temporary path that is used building a project. This folder is where project & packages are copied into, and where the reading and writing takes place.

The default temp folder is a sibling to the current project folder.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #66 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local install and run the `build-project` command

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
