### PR TITLE
fix(Poetry 2): add support for PEP 621 pyproject configuration

### DIFF
--- a/poetry_multiproject_plugin/components/toml/generate.py
+++ b/poetry_multiproject_plugin/components/toml/generate.py
@@ -83,13 +83,18 @@ def generate_valid_dist_project_file(
 
     copy["tool"]["poetry"]["packages"].multiline(True)
 
-    scripts = copy["tool"]["poetry"].get("scripts", {})
+    scripts_pep_621 = copy.get("project", {}).get("scripts", {})
+    scripts_poetry = copy["tool"]["poetry"].get("scripts", {})
 
+    scripts = scripts_pep_621 or scripts_poetry
     if top_ns and scripts:
         rewritten_scripts = {
             k: to_valid_entry(v, top_ns, data) for k, v in scripts.items()
         }
 
-        copy["tool"]["poetry"]["scripts"] = rewritten_scripts
+        if scripts_pep_621:
+            copy["project"]["scripts"] = rewritten_scripts
+        else:
+            copy["tool"]["poetry"]["scripts"] = rewritten_scripts
 
     return tomlkit.dumps(copy)

--- a/poetry_multiproject_plugin/components/toml/read.py
+++ b/poetry_multiproject_plugin/components/toml/read.py
@@ -25,7 +25,9 @@ def package_paths(path: Path) -> List[Path]:
 def project_name(path: Path) -> str:
     data: dict = toml(path)
 
-    return data["tool"]["poetry"]["name"]
+    pep_621_name = data.get("project", {}).get("name")
+
+    return pep_621_name or data["tool"]["poetry"]["name"]
 
 
 def parse_exclude_path(data: dict) -> Union[str, None]:

--- a/test/components/toml/test_generate.py
+++ b/test/components/toml/test_generate.py
@@ -21,6 +21,16 @@ packages = [
 my_cli = "hello.console.app:run"
 """
 
+pyproject_pep_621_cli = """\
+[tool.poetry]
+packages = [
+    {include = "hello", from = "../world"},
+]
+
+[project.scripts]
+my_cli = "hello.console.app:run"
+"""
+
 pyproject_cli_with_local_modules = """\
 [tool.poetry]
 packages = [
@@ -56,6 +66,12 @@ def test_generate_project_file_with_custom_namespace_in_script_entry_point():
     data = generate_toml(pyproject_cli, "xyz")
 
     assert data["tool"]["poetry"]["scripts"] == {"my_cli": "xyz.hello.console.app:run"}
+
+
+def test_generate_project_file_with_custom_namespace_in_script_entry_point_for_pep_621_project():
+    data = generate_toml(pyproject_pep_621_cli, "xyz")
+
+    assert data["project"]["scripts"] == {"my_cli": "xyz.hello.console.app:run"}
 
 
 def test_generate_project_file_with_unchanged_script_entry_point():

--- a/test/components/toml/test_read.py
+++ b/test/components/toml/test_read.py
@@ -1,9 +1,12 @@
+from pathlib import Path
+
 import tomlkit
 
 from poetry_multiproject_plugin.components.toml import read
 
 pyproject = """\
 [tool.poetry]
+name = "unit test"
 """
 
 pyproject_with_exclude_pattern = """\
@@ -19,6 +22,14 @@ exclude = [{"path" = "testing.json"}]
 pyproject_with_complex_exclude_pattern_containing_format = """\
 [tool.poetry]
 exclude = [{"path" = "testing.json", "format" = "wheel"}]
+"""
+
+pyproject_pep_621 = """\
+[tool.poetry]
+packages = []
+
+[project]
+name = "unit test"
 """
 
 
@@ -52,3 +63,19 @@ def test_read_complex_exclude_pattern_with_format_should_return_empty_result():
     res = read.parse_exclude_patterns(data)
 
     assert res == {"testing.json"}
+
+
+def test_get_project_name(monkeypatch):
+    monkeypatch.setattr(read, "toml", lambda _: tomlkit.loads(pyproject))
+
+    name = read.project_name(Path.cwd())
+
+    assert name == "unit test"
+
+
+def test_get_project_name_for_pep_621_project(monkeypatch):
+    monkeypatch.setattr(read, "toml", lambda _: tomlkit.loads(pyproject_pep_621))
+
+    name = read.project_name(Path.cwd())
+
+    assert name == "unit test"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add missing support for Poetry v2 projects using the PEP 621 standard (i.e. the `project` table).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #71 
fixes #72  

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ added unit tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [ ] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
