### PR TITLE
Python 2 adjustments command internals

### DIFF
--- a/poetry_multiproject_plugin/commands/buildproject/project.py
+++ b/poetry_multiproject_plugin/commands/buildproject/project.py
@@ -79,7 +79,12 @@ class ProjectBuildCommand(BuildCommand):
     def prepare_for_build(self, path: Path):
         project_poetry = Factory().create_poetry(path)
 
-        self.set_poetry(project_poetry)
+        if hasattr(self, "set_poetry"):
+            self.set_poetry(project_poetry)
+        elif hasattr(self, "_poetry"):
+            self._poetry = project_poetry
+        else:
+            raise ValueError("Cannot find expected Poetry Command internals.")
 
     def handle(self):
         path = self.poetry.file.path.absolute()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.8.1"
+version = "1.8.2"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 license = "MIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing an issue with changes in the Poetry Command API. The build-project command is creating and setting an instance of the Poetry object in code, to further on run the Build command in a temporary folder.

The API has changed and the `set_poetry` instance method is gone. This Pull Request will check if this method exists, otherwise fallback to setting the internal `self._poetry`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
fixes #72 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run of the project-build command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
