### PR TITLE
fix(check): changes in the Poetry v2 Command API

### DIFF
--- a/poetry_multiproject_plugin/commands/checkproject/check.py
+++ b/poetry_multiproject_plugin/commands/checkproject/check.py
@@ -65,7 +65,12 @@ class ProjectCheckCommand(Command):
     def prepare_for_build(self, path: Path):
         project_poetry = Factory().create_poetry(path)
 
-        self.set_poetry(project_poetry)
+        if hasattr(self, "set_poetry"):
+            self.set_poetry(project_poetry)
+        elif hasattr(self, "_poetry"):
+            self._poetry = project_poetry
+        else:
+            raise ValueError("Cannot find expected Poetry Command internals.")
 
     def handle(self):
         is_verbose = self.option("verbose")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.8.2"
+version = "1.8.3"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 license = "MIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixing an issue caused by the changed Poetry v2 Command API. 

The check-project command fails because of missing "set_poetry".

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Adjust to the current Poetry version and use the "self._poetry" internals as a fallback.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
✅ CI
✅ Local run of the check-project command.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly (if applicable).
