### PR TITLE
fix: Add module name to direct import alias if it is None

### DIFF
--- a/poetry_multiproject_plugin/components/parsing/rewrite.py
+++ b/poetry_multiproject_plugin/components/parsing/rewrite.py
@@ -13,6 +13,8 @@ def mutate_import(node: ast.Import, namespaces: List[str], top_ns: str) -> bool:
 
     for alias in node.names:
         if alias.name in namespaces:
+            if alias.asname is None:
+                alias.asname = alias.name
             alias.name = create_namespace_path(top_ns, alias.name)
             did_mutate = True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "poetry-multiproject-plugin"
-version = "1.8.3"
+version = "1.8.4"
 description = "A Poetry plugin that makes it possible to use relative package includes."
 authors = ["David Vujic"]
 license = "MIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
When importing a module directly (ex: `import example_module`), if it does not use an alias, set the module name as the alias.

## Motivation and Context
When executing `build-project --with-top-namespace example_namespace` the imported modules will be renamed to `example_namespace.example_module`.

In the case of a direct import without alias (ex: `import example_module`), the code will expect to find `example_module` when using said module (ex: `example_module.example_function()` but it will throw a ModuleNotFoundError since it has been renamed to `example_namespace.example_module`.

With this change we set the module name as alias in all the direct imports that do not have one so the code keeps working. (ex: `import example_module` -> `import example_namespace.example_module as example_module`.

## How Has This Been Tested?
Executed unit tests present in the project.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [code of conduct](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CODE-OF-CONDUCT.md).
- [x] I have read the [contributing guide](https://github.com/davidvujic/poetry-multiproject-plugin/blob/master/CONTRIBUTING.md).
- [x] I have updated the documentation accordingly (if applicable).
